### PR TITLE
Формат отображения суммы.

### DIFF
--- a/prices.onlinerby.user.js
+++ b/prices.onlinerby.user.js
@@ -70,9 +70,14 @@
             }
             var exponent = Math.pow(10,decimal_points);
             var num = Math.round((number * exponent)).toString();
-            return num.slice(0,-1*decimal_points) + "." + num.slice(-1*decimal_points)
+            
+            var numSlice = num.slice(0,-1*decimal_points);
+            if (numSlice == "")
+                numSlice = 0;
+            
+            num = numSlice + "." + num.slice(-1*decimal_points);
+            return num.replace(/(\d)(?=(\d\d\d)+([^\d]|$))/g, '$1 ');
         }
-
 
         function hkDetectUsd()
         {


### PR DESCRIPTION
Внесены корректировки в формат отображения суммы в долларах:
1. Разделение пробелами разрядов в целой части суммы (отображалось, к примеру, так: "12345.7"; теперь отображается "12 345.7").
2. Исправлена ошибка, при которой у сумм меньше единицы не отображался 0 перед точкой (отображалось, к примеру, так: ".7"; теперь отображается "0.7").
